### PR TITLE
adding user to the group which has same as username but with different gid

### DIFF
--- a/base_image/config/opt/scripts/usergroupchecker.py
+++ b/base_image/config/opt/scripts/usergroupchecker.py
@@ -99,7 +99,10 @@ def createUser(username, uid, groups):
         print(f"User does not exist. Creating user: {username}")
         grLine = ",".join(groups)
         if grLine:
-            runCmd(f"useradd -u {uid} -s /sbin/nologin -M -g {username} -G {grLine} {username}")
+            if username in groups:
+                runCmd(f"useradd -u {uid} -s /sbin/nologin -M -g {username} -G {grLine} {username}")
+            else:
+                runCmd(f"useradd -u {uid} -s /sbin/nologin -M -G {grLine} {username}")
         else:
             runCmd(f"useradd -u {uid} -s /sbin/nologin -M {username}")
         return


### PR DESCRIPTION
As suggested, I tried with -g option. the cmsuser username adds successfully but the other users (e.g cmslocal)error out saying the user group cmslocal doesn't exists. So, it requires the creation of group before . So this solution doesn't work.
Then tried creating the groups for all the users  before adding the username , but it fails with cmsuser as this group is already created with different gid.

