### PR TITLE
adding content-Type text/plain;instaed of text/html charset=utf-8

### DIFF
--- a/xrootd/xrootd-mon/config/default/opt/http-server.py
+++ b/xrootd/xrootd-mon/config/default/opt/http-server.py
@@ -1,6 +1,6 @@
 import os.path
 
-from flask import Flask
+from flask import Flask, Response
 app = Flask(__name__)
 
 @app.route('/')
@@ -12,5 +12,5 @@ def metrics():
     if os.path.isfile('/srv/xrootd-metrics'):
         with open('/srv/xrootd-metrics', 'rb') as fd:
             content = fd.read()
-        return content.decode('utf-8')
-    raise FileNotFoundError('/srv/xrootd-metrics')
+        return Response(content, status=200, content_type='text/plain; version=0.0.4')
+    return Response("File not found", status=404, content_type='text/plain')


### PR DESCRIPTION
Prometheus was erroring out with "Error scraping target: received unsupported Content-Type "text/html; charset=utf-8" and no fallback_scrape_protocol specified for target " . Hence changed it to text/plain for metrics 