### PR TITLE
update xrooted container Post start to remove Comodo SHA1 signed cert

### DIFF
--- a/xrootd/xrootd-stageout-server/config/default/opt/postStart.sh
+++ b/xrootd/xrootd-stageout-server/config/default/opt/postStart.sh
@@ -4,7 +4,17 @@
 
 mkdir -p /etc/grid-security/xrootd/
 
-cp /etc/grid-security/xrootd*.pem /etc/grid-security/xrootd/
+cp /etc/grid-security/xrootdkey.pem /etc/grid-security/xrootd/
+
+# check if 4th cert is COMODO SHA1 signed root
+openssl storeutl --noout --text --certs /etc/grid-security/xrootdcert.pem | grep "Subject: C=GB, ST=Greater Manchester, L=Salford, O=Comodo CA Limited, CN=AAA Certificate Services"
+if [ $? -eq 0 ]; then
+  # if AAA Certificate Services remove it (keeps only 3)
+  ( openssl x509; openssl x509 ; openssl x509 ) < /etc/grid-security/xrootdcert.pem > /etc/grid-security/xrootd/xrootdcert.pem
+else
+  cp /etc/grid-security/xrootdcert.pem /etc/grid-security/xrootd/xrootdcert.pem
+fi
+
 chown -R xrootd:xrootd /etc/grid-security/xrootd/
 
 cp /tmp/macaroon-secret /etc/xrootd/macaroon-secret


### PR DESCRIPTION
The chain of trust received from inCommon includes SHA1 signed certificate that breaks authentication with FNAL.